### PR TITLE
Added Examples for Stripe.js & Stripe Checkout

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -53,7 +53,8 @@ type ChargeParams struct {
 	// The minimum amount is 50 cents.
 	Amount int64
 
-	// 3-letter ISO code for currency. Currently, only 'usd' is supported.
+	// 3-letter ISO code for currency. Refer to the Stripe docs for currently
+    // supported currencies: https://support.stripe.com/questions/which-currencies-does-stripe-support
 	Currency string
 
 	// (Optional) Either customer or card is required, but not both The ID of an

--- a/examples/checkout_form.html
+++ b/examples/checkout_form.html
@@ -1,0 +1,24 @@
+<!-- Example code taken from https://stripe.com/docs/checkout -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Stripe Checkout Example - go.stripe</title>
+  	<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+</head>
+
+<body>
+	<!-- Set the form action to the route of the handler responsible for receiving the token from Stripe -->
+	<form action="/payment/new" method="POST">
+		<!-- We're using the latest v3 API here -->
+		<script
+		src="https://checkout.stripe.com/v3/checkout.js" class="stripe-button"
+		data-key="{{ .PublishableKey }}"
+		data-amount="2000"
+		data-name="Stripe + Go Demo"
+		data-description="2 widgets ($20.00)"
+		data-currency="usd"
+		data-image="/128x128.png">
+		</script>
+	</form>
+</body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,12 @@
+<!-- Example code taken from https://stripe.com/docs/checkout -->
+
+<head>
+  <title>Stripe + Go Integration Examples - go.stripe</title>
+</head>
+
+<body>
+	<ul>
+		<li><a href="/stripejs">Stripe.js Example</a></li>
+		<li><a href="/checkout">Stripe Checkout Example</a></li>
+	</ul>
+</body>

--- a/examples/stripe_example.go
+++ b/examples/stripe_example.go
@@ -1,0 +1,88 @@
+/*
+
+An example of how to integrate Stripe into your Go application using either
+Stripe.js (https://stripe.com/docs/stripe.js) or
+Stripe Checkout (https://stripe.com/docs/checkout).
+
+These tools will prevent credit card data from hitting your application, making
+it easier to remain PCI compliant and minimising security risks as a result.
+
+See the testing section in Stripe's documentation for a list of test card numbers,
+error codes and other details: https://stripe.com/docs/testing
+
+*/
+
+package main
+
+import (
+	"fmt"
+	"github.com/drone/go.stripe"
+	"html/template"
+	"log"
+	"net/http"
+	"os"
+)
+
+// Defines a template variable for your Stripe publishable key
+type TemplateVars struct {
+	PublishableKey template.HTML
+}
+
+func rootHandler(w http.ResponseWriter, r *http.Request) {
+	t := template.Must(template.ParseFiles("index.html"))
+	t.Execute(w, nil)
+}
+
+func stripeJSHandler(w http.ResponseWriter, r *http.Request) {
+	pubKey := TemplateVars{PublishableKey: template.HTML(os.Getenv("STRIPE_PUB_KEY"))}
+	t := template.Must(template.ParseFiles("stripejs_form.html"))
+	t.Execute(w, pubKey)
+}
+
+func checkoutHandler(w http.ResponseWriter, r *http.Request) {
+	pubKey := TemplateVars{PublishableKey: template.HTML(os.Getenv("STRIPE_PUB_KEY"))}
+	t := template.Must(template.ParseFiles("checkout_form.html"))
+	t.Execute(w, pubKey)
+}
+
+// stripeToken represents a valid card token returned by the Stripe API.
+// We use this to create a charge against the card instead of directly handling
+// the credit card details in our application. Note that you could potentially
+// collect the expiry date to allow you to remind users to update their card
+// details as it nears expiry.
+func paymentHandler(w http.ResponseWriter, r *http.Request) {
+
+	// Use stripe.SetKeyEnv() to read the STRIPE_API_KEY environmental variable or alternatively
+	// use stripe.SetKey() to set it directly (just don't publish it to GitHub!)
+	err := stripe.SetKeyEnv()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	params := stripe.ChargeParams{
+		Desc: "Pastrami on Rye",
+		// Amount as an integer: 2000 = $20.00
+		Amount:   2000,
+		Currency: "AUD",
+		Token:    r.PostFormValue("stripeToken"),
+	}
+
+	_, err = stripe.Charges.Create(&params)
+
+	if err == nil {
+		fmt.Fprintf(w, "Successful test payment!")
+	} else {
+		fmt.Fprintf(w, "Unsuccessful test payment: "+err.Error())
+	}
+
+}
+
+func main() {
+
+	http.HandleFunc("/", rootHandler)
+	http.HandleFunc("/stripejs", stripeJSHandler)
+	http.HandleFunc("/checkout", checkoutHandler)
+	http.HandleFunc("/payment/new", paymentHandler)
+	http.ListenAndServe(":9000", nil)
+}

--- a/examples/stripejs_form.html
+++ b/examples/stripejs_form.html
@@ -1,0 +1,82 @@
+<!-- Example code taken from https://stripe.com/docs/stripe.js/switching -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+  <title>Stripe.js + go.stripe Example</title>
+ 
+  <!-- The required Stripe lib -->
+  <script type="text/javascript" src="https://js.stripe.com/v2/"></script>
+ 
+  <!-- jQuery is used only for this example; it isn't required to use Stripe -->
+  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+ 
+  <script type="text/javascript">
+    // This identifies your website in the createToken call below
+    Stripe.setPublishableKey({{ .PublishableKey }});
+ 
+    var stripeResponseHandler = function(status, response) {
+      var $form = $('#payment-form');
+ 
+      if (response.error) {
+        // Show the errors on the form
+        $form.find('.payment-errors').text(response.error.message);
+        $form.find('button').prop('disabled', false);
+      } else {
+        // token contains id, last4, and card type
+        var token = response.id;
+        // Insert the token into the form so it gets submitted to the server
+        $form.append($('<input type="hidden" name="stripeToken" />').val(token));
+        // and re-submit
+        $form.get(0).submit();
+      }
+    };
+ 
+    jQuery(function($) {
+      $('#payment-form').submit(function(e) {
+        var $form = $(this);
+ 
+        // Disable the submit button to prevent repeated clicks
+        $form.find('button').prop('disabled', true);
+ 
+        Stripe.createToken($form, stripeResponseHandler);
+ 
+        // Prevent the form from submitting with the default action
+        return false;
+      });
+    });
+  </script>
+</head>
+<body>
+  <h1>Charge $20 with Stripe</h1>
+ 
+  <form action="/payment/new" method="POST" id="payment-form">
+    <span class="payment-errors"></span>
+ 
+    <div class="form-row">
+      <label>
+        <span>Card Number</span>
+        <input type="text" size="20" data-stripe="number"/>
+      </label>
+    </div>
+ 
+    <div class="form-row">
+      <label>
+        <span>CVC</span>
+        <input type="text" size="4" data-stripe="cvc"/>
+      </label>
+    </div>
+ 
+    <div class="form-row">
+      <label>
+        <span>Expiration (MM/YYYY)</span>
+        <input type="text" size="2" data-stripe="exp-month"/>
+      </label>
+      <span> / </span>
+      <input type="text" size="4" data-stripe="exp-year"/>
+    </div>
+ 
+    <button type="submit">Submit Payment</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
I've added a couple of examples for how to use go.stripe to create charges using Stripe.js (https://stripe.com/docs/stripe.js) and Stripe Checkout (https://stripe.com/docs/checkout).

The code is relatively simple, but it should help newcomers and promote the "safest" use rather than having the card details pass through their application.

Note that I've also updated a comment re: "USD only" to reflect Stripe's currently supported currencies with a link to their docs.

I've squashed the commits as well.
