### PR TITLE
Fixed typo in invoice object

### DIFF
--- a/examples/stripe_example.go
+++ b/examples/stripe_example.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/drone/go.stripe"
+	"github.com/gardentechno/go.stripe"
 	"html/template"
 	"log"
 	"net/http"

--- a/invoice.go
+++ b/invoice.go
@@ -22,7 +22,7 @@ type Invoice struct {
 	Subtotal        int64         `json:"subtotal"`
 	Total           int64         `json:"total"`
 	Charge          String        `json:"charge"`
-	Customer        string        `json:"closed"`
+	Customer        string        `json:"customer"`
 	Date            int64         `json:"date"`
 	Discount        *Discount     `json:"discount"`
 	Lines           *InvoiceLines `json:"lines"`

--- a/invoice.go
+++ b/invoice.go
@@ -16,6 +16,7 @@ type Invoice struct {
 	AttemptCount    int           `json:"attempt_count"`
 	Attempted       bool          `json:"attempted"`
 	Closed          bool          `json:"closed"`
+	Currency        string        `json:"currency"`
 	Paid            bool          `json:"paid"`
 	PeriodEnd       int64         `json:"period_end"`
 	PeriodStart     int64         `json:"period_start"`

--- a/invoice.go
+++ b/invoice.go
@@ -34,7 +34,10 @@ type Invoice struct {
 }
 
 type InvoiceLines struct {
-	Data []*InvoiceLine `json:"data"`
+	Object string         `json:"object"`
+	Data   []*InvoiceLine `json:"data"`
+	Count  int            `json:"count"`
+	URL    string         `json:"url"`
 }
 
 type InvoiceLine struct {

--- a/invoice.go
+++ b/invoice.go
@@ -33,17 +33,22 @@ type Invoice struct {
 	Livemode        bool          `json:"livemode"`
 }
 
-// InvoiceLines represents an individual line items that is part of an invoice.
 type InvoiceLines struct {
-	InvoiceItems  []*InvoiceItem      `json:"invoiceitems"`
-	Prorations    []*InvoiceItem      `json:"prorations"`
-	Subscriptions []*SubscriptionItem `json:"subscriptions"`
+	Data []*InvoiceLine `json:"data"`
 }
 
-type SubscriptionItem struct {
-	Amount int64   `json:"amount"`
-	Period *Period `json:"period"`
-	Plan   *Plan   `json:"plan"`
+type InvoiceLine struct {
+	Id          string  `json:"id"`
+	Object      string  `json:"object"`
+	Type        string  `json:"type"`
+	Livemode    bool    `json:"livemode"`
+	Amount      int64   `json:"amount"`
+	Currency    string  `json:"currency"`
+	Proration   bool    `json:"proration"`
+	Period      *Period `json:"period"`
+	Quantity    int64   `json:"quantity"`
+	Plan        *Plan   `json:"plan"`
+	Description string  `json:"description"`
 }
 
 type Period struct {


### PR DESCRIPTION
Same thing than https://github.com/drone/go.stripe/pull/24 but on top of the master
