### PR TITLE
Added receipt_email to Charge + Fixed Examples Formatting

### DIFF
--- a/charge.go
+++ b/charge.go
@@ -38,6 +38,7 @@ type Charge struct {
 	Disputed             bool          `json:"disputed"`
 	Livemode             bool          `json:"livemode"`
 	StatementDescription string        `json:"statement_description"`
+	ReceiptEmail         string        `json:"receipt_email"`
 }
 
 // FeeDetails represents a single fee associated with a Charge.
@@ -82,6 +83,12 @@ type ChargeParams struct {
 	// banks display this information consistently, some may display it
 	// incorrectly or not at all.
 	StatementDescription string
+
+	// Receipts are only sent when the payment succeeds. Any `receipt_email`
+	// passed in will override a customer's default email. Emails still will
+	// not be sent in test mode, though live mode `receipt_email`s will ignore
+	// the merchant's customer email settings.
+	ReceiptEmail string
 }
 
 // ChargeClient encapsulates operations for creating, updating, deleting and

--- a/examples/_examples/checkout_form.html
+++ b/examples/_examples/checkout_form.html
@@ -1,0 +1,24 @@
+<!-- Example code taken from https://stripe.com/docs/checkout -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Stripe Checkout Example - go.stripe</title>
+  	<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+</head>
+
+<body>
+	<!-- Set the form action to the route of the handler responsible for receiving the token from Stripe -->
+	<form action="/payment/new" method="POST">
+		<!-- We're using the latest v3 API here -->
+		<script
+		src="https://checkout.stripe.com/v3/checkout.js" class="stripe-button"
+		data-key="{{ .PublishableKey }}"
+		data-amount="2000"
+		data-name="Stripe + Go Demo"
+		data-description="2 widgets ($20.00)"
+		data-currency="usd"
+		data-image="/128x128.png">
+		</script>
+	</form>
+</body>

--- a/examples/_examples/index.html
+++ b/examples/_examples/index.html
@@ -1,0 +1,12 @@
+<!-- Example code taken from https://stripe.com/docs/checkout -->
+
+<head>
+  <title>Stripe + Go Integration Examples - go.stripe</title>
+</head>
+
+<body>
+	<ul>
+		<li><a href="/stripejs">Stripe.js Example</a></li>
+		<li><a href="/checkout">Stripe Checkout Example</a></li>
+	</ul>
+</body>

--- a/examples/_examples/stripe_example.go
+++ b/examples/_examples/stripe_example.go
@@ -1,0 +1,88 @@
+/*
+
+An example of how to integrate Stripe into your Go application using either
+Stripe.js (https://stripe.com/docs/stripe.js) or
+Stripe Checkout (https://stripe.com/docs/checkout).
+
+These tools will prevent credit card data from hitting your application, making
+it easier to remain PCI compliant and minimising security risks as a result.
+
+See the testing section in Stripe's documentation for a list of test card numbers,
+error codes and other details: https://stripe.com/docs/testing
+
+*/
+
+package main
+
+import (
+	"fmt"
+	"github.com/drone/go.stripe"
+	"html/template"
+	"log"
+	"net/http"
+	"os"
+)
+
+// Defines a template variable for your Stripe publishable key
+type TemplateVars struct {
+	PublishableKey template.HTML
+}
+
+func rootHandler(w http.ResponseWriter, r *http.Request) {
+	t := template.Must(template.ParseFiles("index.html"))
+	t.Execute(w, nil)
+}
+
+func stripeJSHandler(w http.ResponseWriter, r *http.Request) {
+	pubKey := TemplateVars{PublishableKey: template.HTML(os.Getenv("STRIPE_PUB_KEY"))}
+	t := template.Must(template.ParseFiles("stripejs_form.html"))
+	t.Execute(w, pubKey)
+}
+
+func checkoutHandler(w http.ResponseWriter, r *http.Request) {
+	pubKey := TemplateVars{PublishableKey: template.HTML(os.Getenv("STRIPE_PUB_KEY"))}
+	t := template.Must(template.ParseFiles("checkout_form.html"))
+	t.Execute(w, pubKey)
+}
+
+// stripeToken represents a valid card token returned by the Stripe API.
+// We use this to create a charge against the card instead of directly handling
+// the credit card details in our application. Note that you could potentially
+// collect the expiry date to allow you to remind users to update their card
+// details as it nears expiry.
+func paymentHandler(w http.ResponseWriter, r *http.Request) {
+
+	// Use stripe.SetKeyEnv() to read the STRIPE_API_KEY environmental variable or alternatively
+	// use stripe.SetKey() to set it directly (just don't publish it to GitHub!)
+	err := stripe.SetKeyEnv()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	params := stripe.ChargeParams{
+		Desc: "Pastrami on Rye",
+		// Amount as an integer: 2000 = $20.00
+		Amount:   2000,
+		Currency: "AUD",
+		Token:    r.PostFormValue("stripeToken"),
+	}
+
+	_, err = stripe.Charges.Create(&params)
+
+	if err == nil {
+		fmt.Fprintf(w, "Successful test payment!")
+	} else {
+		fmt.Fprintf(w, "Unsuccessful test payment: "+err.Error())
+	}
+
+}
+
+func main() {
+
+	http.HandleFunc("/", rootHandler)
+	http.HandleFunc("/stripejs", stripeJSHandler)
+	http.HandleFunc("/checkout", checkoutHandler)
+	http.HandleFunc("/payment/new", paymentHandler)
+	http.ListenAndServe(":9000", nil)
+}

--- a/examples/_examples/stripejs_form.html
+++ b/examples/_examples/stripejs_form.html
@@ -1,0 +1,82 @@
+<!-- Example code taken from https://stripe.com/docs/stripe.js/switching -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+  <title>Stripe.js + go.stripe Example</title>
+ 
+  <!-- The required Stripe lib -->
+  <script type="text/javascript" src="https://js.stripe.com/v2/"></script>
+ 
+  <!-- jQuery is used only for this example; it isn't required to use Stripe -->
+  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+ 
+  <script type="text/javascript">
+    // This identifies your website in the createToken call below
+    Stripe.setPublishableKey({{ .PublishableKey }});
+ 
+    var stripeResponseHandler = function(status, response) {
+      var $form = $('#payment-form');
+ 
+      if (response.error) {
+        // Show the errors on the form
+        $form.find('.payment-errors').text(response.error.message);
+        $form.find('button').prop('disabled', false);
+      } else {
+        // token contains id, last4, and card type
+        var token = response.id;
+        // Insert the token into the form so it gets submitted to the server
+        $form.append($('<input type="hidden" name="stripeToken" />').val(token));
+        // and re-submit
+        $form.get(0).submit();
+      }
+    };
+ 
+    jQuery(function($) {
+      $('#payment-form').submit(function(e) {
+        var $form = $(this);
+ 
+        // Disable the submit button to prevent repeated clicks
+        $form.find('button').prop('disabled', true);
+ 
+        Stripe.createToken($form, stripeResponseHandler);
+ 
+        // Prevent the form from submitting with the default action
+        return false;
+      });
+    });
+  </script>
+</head>
+<body>
+  <h1>Charge $20 with Stripe</h1>
+ 
+  <form action="/payment/new" method="POST" id="payment-form">
+    <span class="payment-errors"></span>
+ 
+    <div class="form-row">
+      <label>
+        <span>Card Number</span>
+        <input type="text" size="20" data-stripe="number"/>
+      </label>
+    </div>
+ 
+    <div class="form-row">
+      <label>
+        <span>CVC</span>
+        <input type="text" size="4" data-stripe="cvc"/>
+      </label>
+    </div>
+ 
+    <div class="form-row">
+      <label>
+        <span>Expiration (MM/YYYY)</span>
+        <input type="text" size="2" data-stripe="exp-month"/>
+      </label>
+      <span> / </span>
+      <input type="text" size="4" data-stripe="exp-year"/>
+    </div>
+ 
+    <button type="submit">Submit Payment</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
Added the new `receipt_email` field to the Charge object.

It allows the API user to specify an email address to send a receipt to in place of the Customer's stored address, or in cases where no Customer has been specified.

I've also fixed some minor formatting issues with the examples (which somehow got pulled into this branch—I can pull them into a separate PR if required).
