### PR TITLE
Fixed issue with get URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 a simple Credit Card processing library for Go using the Stripe API
 
 ```sh
-go get https://github.com/drone/go.stripe
+go get github.com/drone/go.stripe
 ```
 
 ## Examples


### PR DESCRIPTION
Fixed issue where "go get https://github.com/drone/go.stripe" throws error:
package https:/github.com/drone/go.stripe: "https://" not allowed in import path
